### PR TITLE
Improve realism of plutonium fission

### DIFF
--- a/src/simulation/elements/NEUT.cpp
+++ b/src/simulation/elements/NEUT.cpp
@@ -72,28 +72,44 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[i].vx *= 0.995f;
 				parts[i].vy *= 0.995f;
 				break;
-			case PT_PLUT:
-				if (sim->rng.chance(pressureFactor, 1000))
-				{
-					if (sim->rng.chance(1, 3))
-					{
-						sim->create_part(ID(r), x+rx, y+ry, sim->rng.chance(2, 3) ? PT_LAVA : PT_URAN);
-						parts[ID(r)].temp = MAX_TEMP;
-						if (parts[ID(r)].type==PT_LAVA) {
-							parts[ID(r)].tmp = 100;
-							parts[ID(r)].ctype = PT_PLUT;
-						}
-					}
-					else
-					{
-						sim->create_part(ID(r), x+rx, y+ry, PT_NEUT);
-						parts[ID(r)].vx = 0.25f*parts[ID(r)].vx + parts[i].vx;
-						parts[ID(r)].vy = 0.25f*parts[ID(r)].vy + parts[i].vy;
-					}
-					sim->pv[y/CELL][x/CELL] += 10.0f * CFDS; //Used to be 2, some people said nukes weren't powerful enough
-					Element_FIRE_update(UPDATE_FUNC_SUBCALL_ARGS);
-				}
-				break;
+                       case PT_PLUT:
+                       {
+                               int neighbourPlut = 0;
+                               for (int ax = -1; ax <= 1; ++ax)
+                                       for (int ay = -1; ay <= 1; ++ay)
+                                               if (ax || ay)
+                                               {
+                                                       int nx = x + rx + ax;
+                                                       int ny = y + ry + ay;
+                                                       if (InBounds(nx, ny) && TYP(pmap[ny][nx]) == PT_PLUT)
+                                                               neighbourPlut++;
+                                               }
+
+                               if (neighbourPlut >= 4 && sim->rng.chance(neighbourPlut * 50 + pressureFactor, 1000))
+                               {
+                                       sim->create_part(ID(r), x+rx, y+ry, PT_LAVA);
+                                       parts[ID(r)].temp = MAX_TEMP;
+                                       parts[ID(r)].tmp = 100;
+                                       parts[ID(r)].ctype = PT_PLUT;
+
+                                       int id1 = sim->create_part(-1, x+rx, y+ry, PT_NEUT);
+                                       if (id1 >= 0)
+                                       {
+                                               parts[id1].vx = parts[i].vx;
+                                               parts[id1].vy = parts[i].vy;
+                                       }
+                                       int id2 = sim->create_part(-1, x+rx, y+ry, PT_NEUT);
+                                       if (id2 >= 0)
+                                       {
+                                               parts[id2].vx = -parts[i].vx;
+                                               parts[id2].vy = -parts[i].vy;
+                                       }
+
+                                       sim->pv[y/CELL][x/CELL] += 20.0f * CFDS;
+                                       Element_FIRE_update(UPDATE_FUNC_SUBCALL_ARGS);
+                               }
+                               break;
+                       }
 			case PT_DEUT:
 				if (sim->rng.chance(pressureFactor + 1 + (parts[ID(r)].life/100), 1000))
 				{

--- a/src/simulation/elements/PLUT.cpp
+++ b/src/simulation/elements/PLUT.cpp
@@ -31,7 +31,7 @@ void Element::Element_PLUT()
 
 	DefaultProperties.temp = R_TEMP + 4.0f + 273.15f;
 	HeatConduct = 251;
-	Description = "Plutonium. Heavy, fissile particles. Generates neutrons under pressure.";
+       Description = "Plutonium. Heavy, fissile particles. Rarely emits neutrons and can chain react.";
 
 	Properties = TYPE_PART|PROP_NEUTPASS|PROP_RADIOACTIVE;
 
@@ -49,9 +49,26 @@ void Element::Element_PLUT()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (sim->rng.chance(1, 100) && sim->rng.chance(int(5.0f*sim->pv[y/CELL][x/CELL]), 1000))
-	{
-		sim->create_part(i, x, y, PT_NEUT);
-	}
-	return 0;
+       // Count neighbouring plutonium to approximate material density
+       int neighbourPlut = 0;
+       for (int nx = -1; nx <= 1; ++nx)
+       {
+               for (int ny = -1; ny <= 1; ++ny)
+               {
+                       if (!nx && !ny)
+                               continue;
+                       int ax = x + nx;
+                       int ay = y + ny;
+                       if (InBounds(ax, ay) && TYP(pmap[ay][ax]) == PT_PLUT)
+                               neighbourPlut++;
+               }
+       }
+
+       // Spontaneous fission: probability increases slightly with density
+       int chance = 5000; // base 1/5000 chance each frame
+       if (sim->rng.chance(neighbourPlut + 1, chance))
+       {
+               sim->create_part(i, x, y, PT_NEUT);
+       }
+       return 0;
 }


### PR DESCRIPTION
## Summary
- tweak PLUT description and spontaneous neutron emission
- adjust NEUT interaction with PLUT to require nearby fuel and emit extra neutrons

## Testing
- `meson setup build` *(fails: `meson: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a29fd94e8832090ac3d9f84560cb9